### PR TITLE
fix: uses addressable instead of URI for safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.1.2 (8/8/2023)
+* Uses `Addressable::URI` to parse URLs instead of `URI` ([heri](https://github.com/kluein/ssrf_filter/pull/2))
+
 ### 1.1.1 (8/31/2022)
 * Fix network connection errors if you were making https requests while using [net-http](https://github.com/ruby/net-http) 2.2 or higher ([arkadiyt](https://github.com/arkadiyt/ssrf_filter/pull/54))
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@
 
 source 'https://rubygems.org'
 gemspec
+
+gem 'addressable'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This gem provides a safe and easy way to fetch content from user-submitted urls.
 1) Add the gem to your Gemfile:
 
 ```ruby
-gem 'ssrf_filter', '~> 1.1.1'
+gem 'ssrf_filter', '~> 1.1.2'
 ```
 
 2) In your code:

--- a/lib/ssrf_filter/ssrf_filter.rb
+++ b/lib/ssrf_filter/ssrf_filter.rb
@@ -131,7 +131,7 @@ class SsrfFilter
   end
 
   def self.unsafe_url?(url)
-    uri = URI(url)
+    uri = Addressable::URI.parse(url)
 
     get_public_ip_addresses(uri).empty?
   end

--- a/lib/ssrf_filter/version.rb
+++ b/lib/ssrf_filter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SsrfFilter
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end


### PR DESCRIPTION
For safety check, `Addressable` is compatible with newer RFC versions and aligns better with what browsers allow, while `URI` will throw an exception

[More context](https://github.com/kluein/klue/pull/13774#discussion_r1284905410)

After this is merged, a follow-up PR in Klue app will prevent url fails